### PR TITLE
Revert "[DSI-6605] Exclude devices API dependency checks for all environments"

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -14,6 +14,7 @@ module.exports = {
   CONFIG_SEQUELIZE_TYPE: 'sequelize',
   CONFIG_DATABASE_KEY: 'database',
   CONFIG_DEVICES_API_KEY: 'devices',
+  PROD_URL_KEYWORDS: ['__pr__', 'p01', 'p02'],
   CONFIG_API_TYPE: 'api',
   CONFIG_IDENTIFYING_PARTY_SECTION: 'identifyingParty',
   CONFIG_OIDC_SECTION: 'oidc',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@ const rp = require('login.dfe.request-promise-retry');
 const constants = require('../constants/constants');
 
 const {
-  CONFIG_DEVICES_API_KEY, CONFIG_API_TYPE, CONFIG_IDENTIFYING_PARTY_SECTION,
+  CONFIG_DEVICES_API_KEY, PROD_URL_KEYWORDS, CONFIG_API_TYPE, CONFIG_IDENTIFYING_PARTY_SECTION,
 } = constants;
 
 function trimTrailingSlash(str) {
@@ -23,11 +23,16 @@ const checkDependentServiceHealth = async (url) => {
   }
 };
 
+// TODO: remove shouldCheckDevicesApi functionality after the Devices API decommisioning
+const shouldCheckDevicesApi = (key, service) => key !== CONFIG_DEVICES_API_KEY || PROD_URL_KEYWORDS.some((keyword) => service?.url?.includes(keyword));
+
 const getApiUrl = (key, value) => {
   if (value instanceof Object) {
     const { type, service } = value;
-    // TODO: remove Devices API check skip functionality after the Devices API decommisioning - DSI-6365
-    if (type === CONFIG_API_TYPE && service && (key !== CONFIG_DEVICES_API_KEY)) {
+
+    const shouldCheckDevicesAPI = shouldCheckDevicesApi(key, service);
+
+    if (type === CONFIG_API_TYPE && service && shouldCheckDevicesAPI) {
       return service.url || null;
     }
   }
@@ -46,4 +51,5 @@ module.exports = {
   getApiUrl,
   getIdentifyingPartyConfig,
   trimTrailingSlash,
+  shouldCheckDevicesApi,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.healthcheck",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.healthcheck",
-      "version": "4.0.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.healthcheck",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "Express middleware to provide health check endpoints",
   "main": "lib/index.js",
   "scripts": {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,7 +2,7 @@ const rp = require('login.dfe.request-promise-retry');
 
 const {
   CONFIG_DEVICES_API_KEY,
-
+  PROD_URL_KEYWORDS,
   CONFIG_API_TYPE,
   CONFIG_IDENTIFYING_PARTY_SECTION,
   CONFIG_OIDC_SECTION,
@@ -10,6 +10,7 @@ const {
 } = require('../constants/constants');
 const {
   trimTrailingSlash,
+  shouldCheckDevicesApi,
   getApiUrl,
   checkDependentServiceHealth,
   getIdentifyingPartyConfig,
@@ -47,6 +48,33 @@ describe('utils', () => {
     });
   });
 
+  describe('shouldCheckDevicesApi function', () => {
+    it(`should return true when key is not '${CONFIG_DEVICES_API_KEY}'`, () => {
+      const result = shouldCheckDevicesApi('dsi-test-api', { url: 'http://dsi-test-api.com' });
+      expect(result).toBe(true);
+    });
+
+    it(`should return false when key is ${CONFIG_DEVICES_API_KEY} but URL does not include '${PROD_URL_KEYWORDS.join(', ')}' keywords`, () => {
+      const result = shouldCheckDevicesApi(CONFIG_DEVICES_API_KEY, { url: 'http://example.dev' });
+      expect(result).toBe(false);
+    });
+
+    it(`should return true when key is ${CONFIG_DEVICES_API_KEY} and URL includes '${PROD_URL_KEYWORDS.join(', ')}' keywords`, () => {
+      const result = shouldCheckDevicesApi(CONFIG_DEVICES_API_KEY, { url: 'http://p01-devices-api.com' });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when service is undefined', () => {
+      const result = shouldCheckDevicesApi(CONFIG_DEVICES_API_KEY, undefined);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when service url is undefined', () => {
+      const result = shouldCheckDevicesApi(CONFIG_DEVICES_API_KEY, { url: undefined });
+      expect(result).toBe(false);
+    });
+  });
+
   describe('getApiUrl function', () => {
     it('should return null when value is not an object', () => {
       const value = 'string-value';
@@ -66,9 +94,14 @@ describe('utils', () => {
       expect(result).toBe(null);
     });
 
-    it(`should return null when key is ${CONFIG_DEVICES_API_KEY}`, () => {
+    it('should return null when shouldCheckDevicesApi is false', () => {
       const value = { type: CONFIG_API_TYPE, service: { url: 'http://test-api-service.com' } };
-      const result = getApiUrl(CONFIG_DEVICES_API_KEY, value);
+      const result = getApiUrl('devices', value);
+
+      expect(result).toBe(null);
+    });
+    it('should return null when shouldCheckDevicesApi is true but service is not defined', () => {
+      const result = getApiUrl('dsi-test-api', { type: CONFIG_API_TYPE });
 
       expect(result).toBe(null);
     });


### PR DESCRIPTION
Reverting changes due to inefficient use of resources for the `/healthcheck` endpoint.  

This reverts healhtcheck library to V4.0.0 version.

Reverts DFE-Digital/login.dfe.healthcheck#44